### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ayumax/Froola/security/code-scanning/1](https://github.com/ayumax/Froola/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- `contents: read` is required for `actions/checkout` to read the repository contents.
- `contents: write` is not needed since the workflow does not modify repository contents.
- No other permissions (e.g., `issues: write`, `pull-requests: write`) are required because the workflow does not interact with issues or pull requests.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as none of the jobs have specific permission requirements.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
